### PR TITLE
[SPARK-XXXXX][SQL] Part 2: Add CREATE METRIC VIEW command

### DIFF
--- a/sql/api/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseLexer.g4
+++ b/sql/api/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseLexer.g4
@@ -16,6 +16,11 @@
 
 lexer grammar SqlBaseLexer;
 
+@header {
+import java.util.ArrayDeque;
+import java.util.Deque;
+}
+
 @members {
   /**
    * When true, parser should throw ParseException for unclosed bracketed comment.
@@ -69,6 +74,11 @@ lexer grammar SqlBaseLexer;
   public void markUnclosedComment() {
     has_unclosed_bracketed_comment = true;
   }
+
+  /**
+   * This field stores the tags which are used to detect the end of a dollar quoted string literal.
+   */
+  private final Deque<String> tags = new ArrayDeque<String>();
 
   /**
    * When greater than zero, it's in the middle of parsing ARRAY/MAP/STRUCT type.
@@ -325,6 +335,7 @@ MATCHED: 'MATCHED';
 MATERIALIZED: 'MATERIALIZED';
 MAX: 'MAX';
 MERGE: 'MERGE';
+METRICS: 'METRICS';
 MICROSECOND: 'MICROSECOND';
 MICROSECONDS: 'MICROSECONDS';
 MILLISECOND: 'MILLISECOND';
@@ -557,6 +568,10 @@ STRING_LITERAL
     | 'R"'(~'"')* '"'
     ;
 
+BEGIN_DOLLAR_QUOTED_STRING
+    :	DOLLAR_QUOTED_TAG {tags.push(getText());} -> pushMode(DOLLAR_QUOTED_STRING_MODE)
+    ;
+
 DOUBLEQUOTED_STRING
     :'"' ( ~('"'|'\\') | '""' | ('\\' .) )* '"'
     ;
@@ -634,6 +649,10 @@ fragment LETTER
     : [A-Z]
     ;
 
+fragment DOLLAR_QUOTED_TAG
+    : '$' LETTER* '$'
+    ;
+
 fragment UNICODE_LETTER
     : [\p{L}]
     ;
@@ -656,3 +675,14 @@ WS
 UNRECOGNIZED
     : .
     ;
+
+mode DOLLAR_QUOTED_STRING_MODE;
+
+    DOLLAR_QUOTED_STRING_BODY
+        : ~'$'+
+        | '$' ~'$'*
+        ;
+
+    END_DOLLAR_QUOTED_STRING
+        : DOLLAR_QUOTED_TAG {getText().equals(tags.peek())}? {tags.pop();} -> popMode
+        ;

--- a/sql/api/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseParser.g4
+++ b/sql/api/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseParser.g4
@@ -323,6 +323,14 @@ statement
          (PARTITIONED ON identifierList) |
          (TBLPROPERTIES propertyList))*
         AS query                                                       #createView
+    | CREATE (OR REPLACE)?
+        VIEW (IF errorCapturingNot EXISTS)? identifierReference
+        identifierCommentList?
+        ((WITH METRICS) |
+         routineLanguage |
+         commentSpec |
+         (TBLPROPERTIES propertyList))*
+        AS codeLiteral                                                 #createMetricView
     | CREATE (OR REPLACE)? GLOBAL? TEMPORARY VIEW
         tableIdentifier (LEFT_PAREN colTypeList RIGHT_PAREN)? tableProvider
         (OPTIONS propertyList)?                                        #createTempViewUsing
@@ -1521,6 +1529,17 @@ complexColTypeList
 
 complexColType
     : errorCapturingIdentifier COLON? dataType (errorCapturingNot NULL)? commentSpec?
+    ;
+
+// The code literal is defined as a dollar quoted string.
+// A dollar quoted string consists of
+// - a begin tag which contains a dollar sign, an optional tag, and another dollar sign,
+// - a string literal that is made up of arbitrary sequence of characters, and
+// - an end tag which has to be exact the same as the begin tag.
+// As the string literal can contain dollar signs, we add + to DOLLAR_QUOTED_STRING_BODY to avoid
+// the parser eagarly matching END_DOLLAR_QUOTED_STRING when seeing a dollar sign.
+codeLiteral
+    : BEGIN_DOLLAR_QUOTED_STRING DOLLAR_QUOTED_STRING_BODY+ END_DOLLAR_QUOTED_STRING
     ;
 
 routineCharacteristics

--- a/sql/api/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
@@ -618,7 +618,7 @@ private[sql] object QueryParsingErrors extends DataTypeErrorsBase {
       ctx)
   }
 
-  def createViewWithBothIfNotExistsAndReplaceError(ctx: CreateViewContext): Throwable = {
+  def createViewWithBothIfNotExistsAndReplaceError(ctx: ParserRuleContext): Throwable = {
     new ParseException(errorClass = "_LEGACY_ERROR_TEMP_0052", ctx)
   }
 
@@ -773,6 +773,18 @@ private[sql] object QueryParsingErrors extends DataTypeErrorsBase {
         alterTypeMap ++ Map("columnName" -> columnName, "optionName" -> optionName),
       ctx)
   }
+
+  def missingClausesForOperation(
+      ctx: ParserRuleContext,
+      clauses: String,
+      operation: String): Throwable =
+    new ParseException(
+      errorClass = "MISSING_CLAUSES_FOR_OPERATION",
+      messageParameters = Map(
+        "clauses" -> clauses,
+        "operation" -> operation),
+      ctx
+    )
 
   def invalidDatetimeUnitError(
       ctx: ParserRuleContext,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/view.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/view.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.catalyst.analysis
 
 import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, View}
 import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.metricview.logical.ResolvedMetricView
 
 /**
  * This file defines view types and analysis rules related to views.
@@ -32,6 +33,7 @@ import org.apache.spark.sql.catalyst.rules.Rule
 object EliminateView extends Rule[LogicalPlan] with CastSupport {
   override def apply(plan: LogicalPlan): LogicalPlan = plan transformUp {
     case v: View => v.child
+    case rmv: ResolvedMetricView => rmv.child
   }
 }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -49,6 +49,7 @@ import org.apache.spark.sql.connector.catalog.CatalogManager.SESSION_CATALOG_NAM
 import org.apache.spark.sql.errors.{QueryCompilationErrors, QueryExecutionErrors}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.StaticSQLConf.GLOBAL_TEMP_DATABASE
+import org.apache.spark.sql.metricview.util.MetricViewPlanner
 import org.apache.spark.sql.types.{MetadataBuilder, StructField, StructType}
 import org.apache.spark.sql.util.{CaseInsensitiveStringMap, PartitioningUtils}
 import org.apache.spark.util.ArrayImplicits._
@@ -948,8 +949,31 @@ class SessionCatalog(
       // 1. Add a [[View]] operator over the relation to keep track of the view desc;
       // 2. Wrap the logical plan in a [[SubqueryAlias]] which tracks the name of the view.
       SubqueryAlias(multiParts, fromCatalogTable(metadata, isTempView = false))
+    } else if (metadata.tableType == CatalogTableType.METRIC_VIEW) {
+      parseMetricViewDefinition(metadata)
     } else {
       SubqueryAlias(multiParts, UnresolvedCatalogRelation(metadata, options))
+    }
+  }
+
+  private def parseMetricViewDefinition(metadata: CatalogTable): LogicalPlan = {
+    val viewDefinition = metadata.viewText.getOrElse {
+      throw SparkException.internalError("Invalid view without text.")
+    }
+    val viewConfigs = metadata.viewSQLConfigs
+    val origin = CurrentOrigin.get.copy(
+      objectType = Some("METRIC VIEW"),
+      objectName = Some(metadata.qualifiedName)
+    )
+    SQLConf.withExistingConf(
+      View.effectiveSQLConf(
+        configs = viewConfigs,
+        isTempView = false
+      )
+    ) {
+      CurrentOrigin.withOrigin(origin) {
+        MetricViewPlanner.planRead(metadata, viewDefinition, parser, metadata.schema)
+      }
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
@@ -1035,8 +1035,9 @@ object CatalogTableType {
   val EXTERNAL = new CatalogTableType("EXTERNAL")
   val MANAGED = new CatalogTableType("MANAGED")
   val VIEW = new CatalogTableType("VIEW")
+  val METRIC_VIEW = new CatalogTableType("METRIC_VIEW")
 
-  val tableTypes = Seq(EXTERNAL, MANAGED, VIEW)
+  val tableTypes = Seq(EXTERNAL, MANAGED, VIEW, METRIC_VIEW)
 }
 
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParserUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParserUtils.scala
@@ -24,7 +24,7 @@ import scala.util.matching.Regex
 
 import org.antlr.v4.runtime.{ParserRuleContext, Token}
 import org.antlr.v4.runtime.misc.Interval
-import org.antlr.v4.runtime.tree.{ParseTree, TerminalNodeImpl}
+import org.antlr.v4.runtime.tree.{ParseTree, TerminalNode, TerminalNodeImpl}
 
 import org.apache.spark.SparkException
 import org.apache.spark.sql.catalyst.analysis.UnresolvedIdentifier
@@ -86,6 +86,18 @@ object ParserUtils extends SparkParserUtils {
   def stringWithoutUnescape(node: Token): String = {
     // STRING parser rule forces that the input always has quotes at the starting and ending.
     node.getText.slice(1, node.getText.length - 1)
+  }
+
+  /**
+   * Obtain the string literal provided as a dollar quoted string.
+   * A dollar quoted string is defined as {{{$[tag]$<string literal>$[tag]$}}},
+   * where the string literal is parsed as a list of body sections.
+   * This helper method concatenates all body sections and restores the string literal back.
+   */
+  def dollarQuotedString(sections: util.List[TerminalNode]): String = {
+    val sb = new StringBuilder()
+    sections forEach (body => sb.append(body.getText))
+    sb.toString()
   }
 
   /** Collect the entries if any. */

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreePatterns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreePatterns.scala
@@ -149,6 +149,7 @@ object TreePattern extends Enumeration  {
   val LIMIT: Value = Value
   val LOCAL_RELATION: Value = Value
   val LOGICAL_QUERY_STAGE: Value = Value
+  val METRIC_VIEW_PLACEHOLDER: Value = Value
   val NATURAL_LIKE_JOIN: Value = Value
   val NO_GROUPING_AGGREGATE_REFERENCE: Value = Value
   val OFFSET: Value = Value
@@ -162,6 +163,7 @@ object TreePattern extends Enumeration  {
   val RELATION_TIME_TRAVEL: Value = Value
   val REPARTITION_OPERATION: Value = Value
   val REBALANCE_PARTITIONS: Value = Value
+  val RESOLVED_METRIC_VIEW: Value = Value
   val SERIALIZE_FROM_OBJECT: Value = Value
   val SORT: Value = Value
   val SQL_TABLE_FUNCTION: Value = Value

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/metricview/logical/metricViewNodes.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/metricview/logical/metricViewNodes.scala
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.metricview.logical
+
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.catalog.CatalogTable
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeSet}
+import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, UnaryNode}
+import org.apache.spark.sql.catalyst.trees.TreePattern.{METRIC_VIEW_PLACEHOLDER, RESOLVED_METRIC_VIEW, TreePattern}
+import org.apache.spark.sql.metricview.serde.MetricView
+
+case class MetricViewPlaceholder(
+    metadata: CatalogTable,
+    desc: MetricView,
+    outputMetrics: Seq[Attribute],
+    child: LogicalPlan,
+    isCreate: Boolean = false) extends UnaryNode {
+  final override val nodePatterns: Seq[TreePattern] = Seq(METRIC_VIEW_PLACEHOLDER)
+  override protected def withNewChildInternal(newChild: LogicalPlan): LogicalPlan = {
+    copy(child = newChild)
+  }
+  override def output: Seq[Attribute] = outputMetrics
+  override lazy val resolved: Boolean = child.resolved
+  override def simpleString(maxFields: Int): String =
+    s"$nodeName ${output.mkString("[", ", ", "]")}".trim
+
+  override def producedAttributes: AttributeSet = AttributeSet(outputMetrics)
+}
+
+case class ResolvedMetricView(
+    identifier: TableIdentifier,
+    child: LogicalPlan) extends UnaryNode {
+  override def output: scala.Seq[Attribute] = child.output
+  override protected def withNewChildInternal(newChild: LogicalPlan): LogicalPlan =
+    copy(child = newChild)
+  override lazy val resolved: Boolean = child.resolved
+  final override val nodePatterns: Seq[TreePattern] = Seq(RESOLVED_METRIC_VIEW)
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/metricview/util/MetricViewPlanner.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/metricview/util/MetricViewPlanner.scala
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.metricview.util
+
+import org.apache.spark.SparkException
+import org.apache.spark.sql.catalyst.analysis.UnresolvedRelation
+import org.apache.spark.sql.catalyst.catalog.CatalogTable
+import org.apache.spark.sql.catalyst.parser.ParserInterface
+import org.apache.spark.sql.catalyst.plans.logical.{Filter, LogicalPlan}
+import org.apache.spark.sql.catalyst.types.DataTypeUtils
+import org.apache.spark.sql.errors.QueryCompilationErrors
+import org.apache.spark.sql.metricview.logical.MetricViewPlaceholder
+import org.apache.spark.sql.metricview.serde.{AssetSource, MetricView, MetricViewFactory, MetricViewValidationException, MetricViewYAMLParsingException, SQLSource}
+import org.apache.spark.sql.types.StructType
+
+object MetricViewPlanner {
+
+  def planWrite(
+      metadata: CatalogTable,
+      yaml: String,
+      sqlParser: ParserInterface): MetricViewPlaceholder = {
+    val (metricView, dataModelPlan) = parseYAML(yaml, sqlParser)
+    MetricViewPlaceholder(
+      metadata,
+      metricView,
+      Seq.empty,
+      dataModelPlan,
+      isCreate = true
+    )
+  }
+
+  def planRead(
+      metadata: CatalogTable,
+      yaml: String,
+      sqlParser: ParserInterface,
+      expectedSchema: StructType): MetricViewPlaceholder = {
+    val (metricView, dataModelPlan) = parseYAML(yaml, sqlParser)
+    MetricViewPlaceholder(
+      metadata,
+      metricView,
+      DataTypeUtils.toAttributes(expectedSchema),
+      dataModelPlan
+    )
+  }
+
+  private def parseYAML(
+      yaml: String,
+      sqlParser: ParserInterface): (MetricView, LogicalPlan) = {
+    val metricView = try {
+      MetricViewFactory.fromYAML(yaml)
+    } catch {
+      case e: MetricViewValidationException =>
+        throw QueryCompilationErrors.invalidLiteralForWindowDurationError()
+      case e: MetricViewYAMLParsingException =>
+        throw QueryCompilationErrors.invalidLiteralForWindowDurationError()
+    }
+    val source = metricView.from match {
+      case asset: AssetSource => UnresolvedRelation(sqlParser.parseTableIdentifier(asset.name))
+      case sqlSource: SQLSource => sqlParser.parsePlan(sqlSource.sql)
+      case _ => throw SparkException.internalError("Either SQLSource or AssetSource")
+    }
+    // Compute filter here because all necessary information is available.
+    val parsedPlan = metricView.where.map { cond =>
+      Filter(sqlParser.parseExpression(cond), source)
+    }.getOrElse(source)
+    (metricView, parsedPlan)
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveMetricView.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveMetricView.scala
@@ -1,0 +1,207 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.analysis
+
+import scala.collection.mutable
+
+import org.apache.spark.SparkException
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateExpression, Sum}
+import org.apache.spark.sql.catalyst.parser.ParserInterface
+import org.apache.spark.sql.catalyst.plans.logical._
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.catalyst.trees.TreePattern.METRIC_VIEW_PLACEHOLDER
+import org.apache.spark.sql.metricview.logical.{MetricViewPlaceholder, ResolvedMetricView}
+import org.apache.spark.sql.metricview.serde.{Column => CanonicalColumn, Constants => MetricViewConstants, Expression => CanonicalExpression, JsonUtils, MetricView => CanonicalMetricView, _}
+import org.apache.spark.sql.types.{DataType, Metadata, MetadataBuilder}
+
+case class ResolveMetricView(session: SparkSession) extends Rule[LogicalPlan] {
+  private def parser: ParserInterface = session.sessionState.sqlParser
+  override def apply(plan: LogicalPlan): LogicalPlan = {
+    if (!plan.containsPattern(METRIC_VIEW_PLACEHOLDER)) {
+      return plan
+    }
+    plan.resolveOperatorsUp {
+      case mvp: MetricViewPlaceholder if mvp.isCreate && mvp.child.resolved =>
+        val (dimensions, measures) = buildMetricViewOutput(mvp.desc)
+        Aggregate(
+          // group by all dimensions
+          dimensions.map(_.toAttribute).toSeq,
+          // select all dimensions and measures to get the final output (mostly data types)
+          (dimensions ++ measures).toSeq,
+          mvp.child
+        )
+
+      case node @ MetricViewReadOperation(metricView) =>
+        // step 1: parser the metric view definition
+        val (dimensions, measures) =
+          parseMetricViewColumns(metricView.outputMetrics, metricView.desc.select)
+
+        // step 2: build the Project node containing the dimensions
+        val dimensionExprs = dimensions.map(_.namedExpr)
+        // Drop the source columns if it conflicts with dimensions
+        val sourceOutput = metricView.child.output
+        // 1. hide the column conflict with dimensions
+        // 2. add an alias to the source column so they are stable with DeduplicateRelation
+        // 3. metric view output should use the same exprId
+        val sourceProjList = sourceOutput.filterNot { attr =>
+          // conflict with dimensions
+          metricView.outputMetrics
+            .resolve(Seq(attr.name), session.sessionState.conf.resolver)
+            .exists(a => dimensions.exists(_.exprId == a.exprId))
+        }.map { attr =>
+          if (attr.metadata.contains(MetricViewConstants.COLUMN_TYPE_PROPERTY_KEY)) {
+            // no alias for metric view column since the measure reference needs to use the
+            // measure column in MetricViewPlaceholder, but an alias will change the exprId
+            attr
+          } else {
+            // add an alias to the source column so they are stable with DeduplicateRelation
+            Alias(attr, attr.name)()
+          }
+        }
+        val withDimensions = node.transformDownWithPruning(
+          _.containsPattern(METRIC_VIEW_PLACEHOLDER)) {
+          case mv: MetricViewPlaceholder
+            if mv.metadata.identifier == metricView.metadata.identifier =>
+            ResolvedMetricView(
+              mv.metadata.identifier,
+              Project(sourceProjList ++ dimensionExprs, mv.child)
+            )
+        }
+
+        // step 3: resolve the measure references in Aggregate node
+        val res = withDimensions match {
+          case aggregate: Aggregate => transformAggregateWithMeasures(
+            aggregate,
+            measures
+          )
+          case other =>
+            throw SparkException.internalError("ran into unexpected node: " + other)
+        }
+        res
+    }
+  }
+
+  private def buildMetricViewOutput(metricView: CanonicalMetricView)
+  : (Seq[NamedExpression], Seq[NamedExpression]) = {
+    val dimensions = new mutable.ArrayBuffer[NamedExpression]()
+    val measures = new mutable.ArrayBuffer[NamedExpression]()
+    metricView.select.foreach { col =>
+      val metadata = new MetadataBuilder()
+        .withMetadata(Metadata.fromJson(JsonUtils.toJson(col.getColumnMetadata)))
+        .build()
+      col.expression match {
+        case DimensionExpression(expr) =>
+          dimensions.append(
+            Alias(parser.parseExpression(expr), col.name)(explicitMetadata = Some(metadata)))
+        case MeasureExpression(expr) =>
+          measures.append(
+            Alias(parser.parseExpression(expr), col.name)(explicitMetadata = Some(metadata)))
+      }
+    }
+    (dimensions.toSeq, measures.toSeq)
+  }
+
+  private def parseMetricViewColumns(
+      metricViewOutput: Seq[Attribute],
+      columns: Seq[CanonicalColumn[_ <: CanonicalExpression]]
+  ): (Seq[MetricViewDimension], Seq[MetricViewMeasure]) = {
+    val dimensions = new mutable.ArrayBuffer[MetricViewDimension]()
+    val measures = new mutable.ArrayBuffer[MetricViewMeasure]()
+    metricViewOutput.zip(columns).foreach { case (attr, column) =>
+      column.expression match {
+        case DimensionExpression(expr) =>
+          dimensions.append(
+            MetricViewDimension(
+              attr.name,
+              parser.parseExpression(expr),
+              attr.exprId,
+              attr.dataType)
+          )
+        case MeasureExpression(expr) =>
+          measures.append(
+            MetricViewMeasure(
+              attr.name,
+              parser.parseExpression(expr),
+              attr.exprId,
+              attr.dataType)
+          )
+      }
+    }
+    (dimensions.toSeq, measures.toSeq)
+  }
+
+  private def transformAggregateWithMeasures(
+      aggregate: Aggregate,
+      measures: Seq[MetricViewMeasure]): LogicalPlan = {
+    val measuresMap = measures.map(m => m.exprId -> m).toMap
+    val newAggExprs = aggregate.aggregateExpressions.map { expr =>
+      expr.transform {
+        case AggregateExpression(Sum(a: AttributeReference, _), _, _, _, _) =>
+          measuresMap(a.exprId).expr
+      }.asInstanceOf[NamedExpression]
+    }
+    aggregate.copy(aggregateExpressions = newAggExprs)
+  }
+}
+
+object MetricViewReadOperation {
+  def unapply(plan: LogicalPlan): Option[MetricViewPlaceholder] = {
+    plan match {
+      case a: Aggregate if a.resolved && a.containsPattern(METRIC_VIEW_PLACEHOLDER) =>
+        collectMetricViewNode(a.child)
+      case _ =>
+        None
+    }
+  }
+
+  @scala.annotation.tailrec
+  private def collectMetricViewNode(plan: LogicalPlan): Option[MetricViewPlaceholder] = {
+    plan match {
+      case f: Filter => collectMetricViewNode(f.child)
+      case s: Expand => collectMetricViewNode(s.child)
+      case s: Project => collectMetricViewNode(s.child)
+      case s: SubqueryAlias => collectMetricViewNode(s.child)
+      case m: MetricViewPlaceholder => Some(m)
+      case _ => None
+    }
+  }
+}
+
+sealed trait MetricViewColumn {
+  def name: String
+  def expr: Expression
+  def exprId: ExprId
+  def dataType: DataType
+  def namedExpr: NamedExpression = {
+    Alias(UpCast(expr, dataType), name)(exprId = exprId)
+  }
+}
+
+case class MetricViewDimension(
+    name: String,
+    expr: Expression,
+    exprId: ExprId,
+    dataType: DataType) extends MetricViewColumn
+
+case class MetricViewMeasure(
+    name: String,
+    expr: Expression,
+    exprId: ExprId,
+    dataType: DataType) extends MetricViewColumn

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/metricViewCommands.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/metricViewCommands.scala
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.command
+
+import org.apache.spark.sql.{Row, SparkSession}
+import org.apache.spark.sql.catalyst.{QueryPlanningTracker, TableIdentifier}
+import org.apache.spark.sql.catalyst.analysis.{ResolvedIdentifier, SchemaUnsupported}
+import org.apache.spark.sql.catalyst.catalog.{CatalogStorageFormat, CatalogTable, CatalogTableType}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference}
+import org.apache.spark.sql.catalyst.plans.logical.{IgnoreCachedData, LogicalPlan}
+import org.apache.spark.sql.errors.QueryCompilationErrors
+import org.apache.spark.sql.metricview.util.MetricViewPlanner
+import org.apache.spark.sql.types.{StringType, StructType}
+
+case class CreateMetricViewCommand(
+    child: LogicalPlan,
+    userSpecifiedColumns: Seq[(String, Option[String])],
+    comment: Option[String],
+    properties: Map[String, String],
+    originalText: String,
+    allowExisting: Boolean,
+    replace: Boolean) extends UnaryRunnableCommand with IgnoreCachedData {
+
+  import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
+
+  override val output: Seq[Attribute] = Seq(
+    AttributeReference("result", StringType, nullable = false)()
+  )
+  override def run(sparkSession: SparkSession): Seq[Row] = {
+    logInfo("#### CreateMetricViewCommand, text: " + originalText)
+    val catalog = sparkSession.sessionState.catalog
+    val name = child match {
+      case v: ResolvedIdentifier =>
+        v.identifier.asTableIdentifier
+      case _ => throw QueryCompilationErrors.loadDataNotSupportedForV2TablesError()
+    }
+    val analyzed = MetricViewHelper.analyzeMetricViewText(sparkSession, name, originalText)
+
+    if (userSpecifiedColumns.nonEmpty) {
+      if (userSpecifiedColumns.length > analyzed.output.length) {
+        throw QueryCompilationErrors.cannotCreateViewNotEnoughColumnsError(
+          name, userSpecifiedColumns.map(_._1), analyzed)
+      } else if (userSpecifiedColumns.length < analyzed.output.length) {
+        throw QueryCompilationErrors.cannotCreateViewTooManyColumnsError(
+          name, userSpecifiedColumns.map(_._1), analyzed)
+      }
+    }
+    catalog.createTable(
+      ViewHelper.prepareTable(
+        sparkSession, name, Some(originalText), analyzed, userSpecifiedColumns,
+        properties, SchemaUnsupported, comment,
+        None, isMetricView = true),
+      ignoreIfExists = allowExisting)
+    Seq.empty
+  }
+  override protected def withNewChildInternal(newChild: LogicalPlan): LogicalPlan = {
+    copy(child = newChild)
+  }
+}
+
+case class AlterMetricViewCommand(child: LogicalPlan, originalText: String)
+
+object MetricViewHelper {
+  def analyzeMetricViewText(
+      session: SparkSession,
+      name: TableIdentifier,
+      viewText: String): LogicalPlan = {
+    val analyzer = session.sessionState.analyzer
+    // this metadata is used for analysis check, it'll be replaced during create/update with
+    // more accurate information
+    val tableMeta = CatalogTable(identifier = name, tableType = CatalogTableType.METRIC_VIEW,
+      storage = CatalogStorageFormat.empty, schema = new StructType(),
+      viewOriginalText = Some(viewText), viewText = Some(viewText))
+    val metricViewNode = MetricViewPlanner.planWrite(
+      tableMeta, viewText, session.sessionState.sqlParser)
+    val analyzed = analyzer.executeAndCheck(metricViewNode, new QueryPlanningTracker)
+    ViewHelper.verifyTemporaryObjectsNotExists(isTemporary = false, name, analyzed, Seq.empty)
+    analyzed
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/views.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/views.scala
@@ -133,7 +133,7 @@ case class CreateViewCommand(
     SchemaUtils.checkIndeterminateCollationInSchema(plan.schema)
 
     if (viewType == LocalTempView) {
-      val aliasedPlan = aliasPlan(sparkSession, analyzedPlan)
+      val aliasedPlan = aliasPlan(sparkSession, analyzedPlan, userSpecifiedColumns)
       val tableDefinition = createTemporaryViewRelation(
         name,
         sparkSession,
@@ -148,7 +148,7 @@ case class CreateViewCommand(
     } else if (viewType == GlobalTempView) {
       val db = sparkSession.sessionState.conf.getConf(StaticSQLConf.GLOBAL_TEMP_DATABASE)
       val viewIdent = TableIdentifier(name.table, Option(db))
-      val aliasedPlan = aliasPlan(sparkSession, analyzedPlan)
+      val aliasedPlan = aliasPlan(sparkSession, analyzedPlan, userSpecifiedColumns)
       val tableDefinition = createTemporaryViewRelation(
         viewIdent,
         sparkSession,
@@ -178,7 +178,10 @@ case class CreateViewCommand(
         // Handles `CREATE OR REPLACE VIEW v0 AS SELECT ...`
         // Nothing we need to retain from the old view, so just drop and create a new one
         catalog.dropTable(viewIdent, ignoreIfNotExists = false, purge = false)
-        catalog.createTable(prepareTable(sparkSession, analyzedPlan), ignoreIfExists = false)
+        catalog.createTable(
+          prepareTable(
+            sparkSession, name, originalText, analyzedPlan, userSpecifiedColumns, properties,
+            viewSchemaMode, comment, collation), ignoreIfExists = false)
       } else {
         // Handles `CREATE VIEW v0 AS SELECT ...`. Throws exception when the target view already
         // exists.
@@ -186,54 +189,12 @@ case class CreateViewCommand(
       }
     } else {
       // Create the view if it doesn't exist.
-      catalog.createTable(prepareTable(sparkSession, analyzedPlan), ignoreIfExists = allowExisting)
+      catalog.createTable(
+        prepareTable(
+          sparkSession, name, originalText, analyzedPlan, userSpecifiedColumns, properties,
+          viewSchemaMode, comment, collation), ignoreIfExists = allowExisting)
     }
     Seq.empty[Row]
-  }
-
-  /**
-   * If `userSpecifiedColumns` is defined, alias the analyzed plan to the user specified columns,
-   * else return the analyzed plan directly.
-   */
-  private def aliasPlan(session: SparkSession, analyzedPlan: LogicalPlan): LogicalPlan = {
-    if (userSpecifiedColumns.isEmpty) {
-      analyzedPlan
-    } else {
-      val projectList = analyzedPlan.output.zip(userSpecifiedColumns).map {
-        case (attr, (colName, None)) => Alias(attr, colName)()
-        case (attr, (colName, Some(colComment))) =>
-          val meta = new MetadataBuilder().putString("comment", colComment).build()
-          Alias(attr, colName)(explicitMetadata = Some(meta))
-      }
-      session.sessionState.executePlan(Project(projectList, analyzedPlan)).analyzed
-    }
-  }
-
-  /**
-   * Returns a [[CatalogTable]] that can be used to save in the catalog. Generate the view-specific
-   * properties(e.g. view default database, view query output column names) and store them as
-   * properties in the CatalogTable, and also creates the proper schema for the view.
-   */
-  private def prepareTable(session: SparkSession, analyzedPlan: LogicalPlan): CatalogTable = {
-    if (originalText.isEmpty) {
-      throw QueryCompilationErrors.createPersistedViewFromDatasetAPINotAllowedError()
-    }
-    val aliasedSchema = CharVarcharUtils.getRawSchema(
-      aliasPlan(session, analyzedPlan).schema, session.sessionState.conf)
-    val newProperties = generateViewProperties(
-      properties, session, analyzedPlan.schema.fieldNames, aliasedSchema.fieldNames, viewSchemaMode)
-
-    CatalogTable(
-      identifier = name,
-      tableType = CatalogTableType.VIEW,
-      storage = CatalogStorageFormat.empty,
-      schema = aliasedSchema,
-      properties = newProperties,
-      viewOriginalText = originalText,
-      viewText = originalText,
-      comment = comment,
-      collation = collation
-    )
   }
 
   override def withCTEDefs(cteDefs: Seq[CTERelationDef]): LogicalPlan = {
@@ -811,5 +772,64 @@ object ViewHelper extends SQLConfHelper with Logging with CapturesConfig {
       schema = analyzedPlan.schema,
       properties = Map((VIEW_STORING_ANALYZED_PLAN, "true")),
       collation = collation)
+  }
+
+
+  /**
+   * Returns a [[CatalogTable]] that can be used to save in the catalog. Generate the view-specific
+   * properties(e.g. view default database, view query output column names) and store them as
+   * properties in the CatalogTable, and also creates the proper schema for the view.
+   */
+  def prepareTable(
+      session: SparkSession,
+      name: TableIdentifier,
+      originalText: Option[String],
+      analyzedPlan: LogicalPlan,
+      userSpecifiedColumns: Seq[(String, Option[String])],
+      properties: Map[String, String],
+      viewSchemaMode: ViewSchemaMode,
+      comment: Option[String],
+      collation: Option[String],
+      isMetricView: Boolean = false): CatalogTable = {
+    if (originalText.isEmpty) {
+      throw QueryCompilationErrors.createPersistedViewFromDatasetAPINotAllowedError()
+    }
+    val aliasedSchema = CharVarcharUtils.getRawSchema(
+      aliasPlan(session, analyzedPlan, userSpecifiedColumns).schema, session.sessionState.conf)
+    val newProperties = generateViewProperties(
+      properties, session, analyzedPlan.schema.fieldNames, aliasedSchema.fieldNames, viewSchemaMode)
+
+    CatalogTable(
+      identifier = name,
+      tableType = if (isMetricView) CatalogTableType.METRIC_VIEW else CatalogTableType.VIEW,
+      storage = CatalogStorageFormat.empty,
+      schema = aliasedSchema,
+      properties = newProperties,
+      viewOriginalText = originalText,
+      viewText = originalText,
+      comment = comment,
+      collation = collation
+    )
+  }
+
+  /**
+   * If `userSpecifiedColumns` is defined, alias the analyzed plan to the user specified columns,
+   * else return the analyzed plan directly.
+   */
+  def aliasPlan(
+      session: SparkSession,
+      analyzedPlan: LogicalPlan,
+      userSpecifiedColumns: Seq[(String, Option[String])]): LogicalPlan = {
+    if (userSpecifiedColumns.isEmpty) {
+      analyzedPlan
+    } else {
+      val projectList = analyzedPlan.output.zip(userSpecifiedColumns).map {
+        case (attr, (colName, None)) => Alias(attr, colName)()
+        case (attr, (colName, Some(colComment))) =>
+          val meta = new MetadataBuilder().putString("comment", colComment).build()
+          Alias(attr, colName)(explicitMetadata = Some(meta))
+      }
+      session.sessionState.executePlan(Project(projectList, analyzedPlan)).analyzed
+    }
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/BaseSessionStateBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/BaseSessionStateBuilder.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.internal
 import org.apache.spark.annotation.Unstable
 import org.apache.spark.sql.{DataSourceRegistration, ExperimentalMethods, SparkSessionExtensions, UDTFRegistration}
 import org.apache.spark.sql.artifact.ArtifactManager
-import org.apache.spark.sql.catalyst.analysis.{Analyzer, EvalSubqueriesForTimeTravel, FunctionRegistry, InvokeProcedures, ReplaceCharWithVarchar, ResolveDataSource, ResolveEventTimeWatermark, ResolveExecuteImmediate, ResolveSessionCatalog, ResolveTranspose, TableFunctionRegistry}
+import org.apache.spark.sql.catalyst.analysis.{Analyzer, EvalSubqueriesForTimeTravel, FunctionRegistry, InvokeProcedures, ReplaceCharWithVarchar, ResolveDataSource, ResolveEventTimeWatermark, ResolveExecuteImmediate, ResolveMetricView, ResolveSessionCatalog, ResolveTranspose, TableFunctionRegistry}
 import org.apache.spark.sql.catalyst.analysis.resolver.ResolverExtension
 import org.apache.spark.sql.catalyst.catalog.{FunctionExpressionBuilder, SessionCatalog}
 import org.apache.spark.sql.catalyst.expressions.{Expression, ExtractSemiStructuredFields}
@@ -243,6 +243,7 @@ abstract class BaseSessionStateBuilder(
         ResolveWriteToStream +:
         new EvalSubqueriesForTimeTravel +:
         new ResolveTranspose(session) +:
+        ResolveMetricView(session) +:
         new InvokeProcedures(session) +:
         ResolveExecuteImmediate(session, this.catalogManager) +:
         ExtractSemiStructuredFields +:

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/MetricViewSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/MetricViewSuite.scala
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution
+
+import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.metricview.serde.{AssetSource, Column, DimensionExpression, MeasureExpression, MetricView, MetricViewFactory}
+import org.apache.spark.sql.test.{SharedSparkSession, SQLTestUtils}
+
+class MetricViewSuite extends QueryTest with SQLTestUtils with SharedSparkSession {
+
+  private def createMetricView(metricView: MetricView): Unit = {
+    val yaml = MetricViewFactory.toYAML(metricView)
+    sql(s"""
+        |CREATE VIEW my_metric_view
+        |WITH METRICS
+        |LANGUAGE YAML
+        |AS
+        |$$$$
+        |$yaml
+        |$$$$
+        |""".stripMargin)
+  }
+
+  test("basic") {
+    val sparkSession = this.spark
+    import sparkSession.implicits._
+    val metricViewColumns = Seq(
+      Column("d1", DimensionExpression("upper(a)"), 0),
+      Column("m1", MeasureExpression("sum(b)"), 1)
+    )
+    Seq(
+      "x" -> 1,
+      "x" -> 2,
+      "y" -> 3,
+      "y" -> 4
+    ).toDF("a", "b").write.mode("overwrite").saveAsTable("my_table")
+    val metricView = MetricView("0.1", AssetSource("my_table"), Some("b > 1"), metricViewColumns)
+    createMetricView(metricView)
+    val df = sql("select d1, sum(m1) from my_metric_view group by d1")
+    df.explain(true)
+    df.show(false)
+  }
+}

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionStateBuilder.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionStateBuilder.scala
@@ -25,7 +25,7 @@ import org.apache.hadoop.hive.ql.exec.{UDAF, UDF}
 import org.apache.hadoop.hive.ql.udf.generic.{AbstractGenericUDAFResolver, GenericUDF, GenericUDTF}
 
 import org.apache.spark.sql.AnalysisException
-import org.apache.spark.sql.catalyst.analysis.{Analyzer, EvalSubqueriesForTimeTravel, InvokeProcedures, ReplaceCharWithVarchar, ResolveDataSource, ResolveExecuteImmediate, ResolveSessionCatalog, ResolveTranspose}
+import org.apache.spark.sql.catalyst.analysis.{Analyzer, EvalSubqueriesForTimeTravel, InvokeProcedures, ReplaceCharWithVarchar, ResolveDataSource, ResolveExecuteImmediate, ResolveMetricView, ResolveSessionCatalog, ResolveTranspose}
 import org.apache.spark.sql.catalyst.analysis.resolver.ResolverExtension
 import org.apache.spark.sql.catalyst.catalog.{ExternalCatalogWithListener, InvalidUDFClassException}
 import org.apache.spark.sql.catalyst.expressions.{Expression, ExtractSemiStructuredFields}
@@ -132,6 +132,7 @@ class HiveSessionStateBuilder(
         new EvalSubqueriesForTimeTravel +:
         new DetermineTableStats(session) +:
         new ResolveTranspose(session) +:
+        ResolveMetricView(session) +:
         new InvokeProcedures(session) +:
         ResolveExecuteImmediate(session, catalogManager) +:
         ExtractSemiStructuredFields +:


### PR DESCRIPTION
This commit implements the SQL syntax and command for creating metric views:

- Add SQL grammar support:
  - Add METRICS keyword to lexer
  - Add dollar-quoted string support for YAML definitions
  - Add createMetricView production rule
- Add METRIC_VIEW catalog table type
- Implement CreateMetricViewCommand:
  - Parse YAML definition
  - Build MetricViewPlaceholder logical node
  - Validate and analyze metric view
- Add MetricViewPlaceholder logical node with tree patterns
- Update ViewHelper to support metric view creation
- Add basic test suite for metric views

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

[SPARK-XXXXX][SQL] Part 3: Add metric view query resolution

This commit implements the query functionality for metric views:

- Add MetricViewPlanner utility:
  - planRead() to parse metric view for SELECT queries
  - planWrite() refactored from metricViewCommands
  - parseYAML() shared parsing logic
- Add ResolveMetricView analyzer rule:
  - Transform MetricViewPlaceholder into aggregation queries
  - Parse dimensions and measures from schema metadata
  - Build Project with dimensions and Aggregate with measures
  - Handle measure references in aggregates
- Update SessionCatalog to parse metric view definitions on read
- Update EliminateView to handle ResolvedMetricView nodes
- Refactor CreateMetricViewCommand to use MetricViewPlanner
- Update ViewHelper to set METRIC_VIEW table type correctly
- Add ResolveMetricView to analyzer rule chain
- Update test suite with query tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

update

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
